### PR TITLE
Fix compile error on GCC-12/Ubuntu 22.04

### DIFF
--- a/src/Gen-ZAM.cc
+++ b/src/Gen-ZAM.cc
@@ -2,6 +2,7 @@
 
 #include "Gen-ZAM.h"
 
+#include <cstring>
 #include <ctype.h>
 #include <regex>
 


### PR DESCRIPTION
Error

```
[116/1252] Building CXX object auxil/gen-zam/CMakeFiles/gen-zam.dir/src/Gen-ZAM.cc.o
FAILED: auxil/gen-zam/CMakeFiles/gen-zam.dir/src/Gen-ZAM.cc.o
/usr/bin/ccache /usr/bin/g++-12 -DDOCTEST_CONFIG_SUPER_FAST_ASSERTS  -Wall -Wno-unused -g -DDEBUG -DBRO_DEBUG -Wno-register -Werror=vla -g -MD -MT auxil/gen-zam/CMakeFiles/gen-zam.dir/src/Gen-ZAM.cc.o -MF auxil/gen-zam/CMakeFiles/gen-zam.dir/src/Gen-ZAM.cc.o.d -o auxil/gen-zam/CMakeFiles/gen-zam.dir/src/Gen-ZAM.cc.o -c /home/johanna/zeek/auxil/gen-zam/src/Gen-ZAM.cc
/home/johanna/zeek/auxil/gen-zam/src/Gen-ZAM.cc: In member function ‘void TemplateInput::Gripe(const char*, const std::string&) const’:
/home/johanna/zeek/auxil/gen-zam/src/Gen-ZAM.cc:1896:17: error: ‘strlen’ was not declared in this scope
 1896 |         int n = strlen(input_s);
      |                 ^~~~~~
/home/johanna/zeek/auxil/gen-zam/src/Gen-ZAM.cc:7:1: note: ‘strlen’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
    6 | #include <regex>
  +++ |+#include <cstring>
    7 |
/home/johanna/zeek/auxil/gen-zam/src/Gen-ZAM.cc: In constructor ‘ZAMGen::ZAMGen(int, char**)’:
/home/johanna/zeek/auxil/gen-zam/src/Gen-ZAM.cc:1922:18: error: ‘strcmp’ was not declared in this scope
 1922 |         auto f = strcmp(file_name, "-") ? fopen(file_name, "r") : stdin;
      |                  ^~~~~~
/home/johanna/zeek/auxil/gen-zam/src/Gen-ZAM.cc:1922:18: note: ‘strcmp’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?

```