### PR TITLE
Adding Windows support for the Gen-Zam submodule

### DIFF
--- a/src/Gen-ZAM.cc
+++ b/src/Gen-ZAM.cc
@@ -1381,7 +1381,7 @@ void ZAM_ExprOpTemplate::InstantiateEval(const vector<ZAM_OperandType>& ot_orig,
 
 			auto replacement = VecEvalRE(has_target);
 
-			eval = regex_replace(eval, regex(rhs), replacement);
+			eval = regex_replace(eval, regex(rhs), replacement, std::regex_constants::match_not_null);
 			}
 
 		auto is_none = ei.LHS_ET() == ZAM_EXPR_TYPE_NONE;


### PR DESCRIPTION
Fix a bug caused by different behaviour of std::regex_replace under MSVC.

Under MSVC regex objects are multiline by default and there is no apparant way of changing this behaviour. Under clang/gcc regex is singleline unless std::regeX_constants::multiline is specificied. This behaviour is assumed in Gen-ZAM.cc when auto-generating header files.

Example: https://godbolt.org/z/aP59x3EhT