### PR TITLE
better error reporting when ZAM code does a function call

### DIFF
--- a/src/Gen-ZAM.cc
+++ b/src/Gen-ZAM.cc
@@ -1825,7 +1825,7 @@ void ZAM_InternalOpTemplate::Parse(const string& attr, const string& line, const
 				}
 		}
 
-	eval += "f->SetCallLoc(z.loc);\n";
+	eval += "f->SetCall(z.call_expr);\n";
 
 	if ( HasAssignVal() )
 		{


### PR DESCRIPTION
This change goes in hand with a ZAM maintenance PR that I'm about to put in.  It improves the information available when generating error messages associated with functions called by ZAM code.