### PR TITLE
fix to make generated function calls compatible with "when" lambdas

### DIFF
--- a/src/Gen-ZAM.cc
+++ b/src/Gen-ZAM.cc
@@ -1825,7 +1825,7 @@ void ZAM_InternalOpTemplate::Parse(const string& attr, const string& line, const
 				}
 		}
 
-	eval += "f->SetCall(z.call_expr);\n";
+	eval += "f->SetOnlyCall(z.call_expr);\n";
 
 	if ( HasAssignVal() )
 		{


### PR DESCRIPTION
I'm about to put in a large PR for ZAM feature completeness.  This tweak is needed for generating correct calls for `when` lambdas.