### PR TITLE
support for ZAM instructions using IntrusivePtr for call expression ASTs

### DIFF
--- a/src/Gen-ZAM.cc
+++ b/src/Gen-ZAM.cc
@@ -1825,7 +1825,7 @@ void ZAM_InternalOpTemplate::Parse(const string& attr, const string& line, const
 				}
 		}
 
-	eval += "f->SetOnlyCall(z.call_expr);\n";
+	eval += "f->SetOnlyCall(z.call_expr.get());\n";
 
 	if ( HasAssignVal() )
 		{


### PR DESCRIPTION
This tweak is a companion to an upcoming ZAM PR that makes more careful use of pointers to enable discarding of ASTs to save memory. I'll update this with that PR once it's available.