### PR TITLE
Fixes for generating ZAM operations relating to indirect calls

### DIFF
--- a/src/Gen-ZAM.h
+++ b/src/Gen-ZAM.h
@@ -847,6 +847,9 @@ private:
 	// True if the internal operation corresponds to an indirect call,
 	// i.e., one through a variable rather than one directly specified.
 	bool is_indirect_call = false;
+
+	// Refinement of is_indirect_call, when it's also via a local variable.
+	bool is_local_indirect_call = false;
 	};
 
 // An internal operation that assigns a result to a frame element.


### PR DESCRIPTION
This PR is in preparation for an upcoming batch of ZAM maintenance & enhancements. This change should be backward compatible with the existing ZAM code, so easy enough to do stand-alone.