### PR TITLE
Hooks for supporting ZAM profiling

### DIFF
--- a/src/Gen-ZAM.h
+++ b/src/Gen-ZAM.h
@@ -523,6 +523,9 @@ protected:
 	// The C++ evaluation; may span multiple lines.
 	string eval;
 
+	// Postlog C++ code (currently only used in support of profiling).
+	string post_eval;
+
 	// Any associated custom method.
 	string custom_method;
 


### PR DESCRIPTION
This PR is a companion to one I'm about to put in for main Zeek. Here we're adding generation of hooks to tie into ZAM profiling when generating ZAM instructions. The two PRs need to be merged together, as this change is not backward-compatible with previous versions of ZAM. 