### PR TITLE
Fix for generating relational operations

### DIFF
--- a/src/Gen-ZAM.cc
+++ b/src/Gen-ZAM.cc
@@ -1684,7 +1684,12 @@ void ZAM_RelationalExprOpTemplate::BuildInstruction(const vector<ZAM_OperandType
 			op1 = "n1";
 		}
 	else
-		op1 = "n2";
+		{
+		if ( ot[1] == ZAM_OT_CONSTANT )
+			op1 = "c";
+		else
+			op1 = "n2";
+		}
 
 	auto type_suffix = zc == ZIC_VEC ? "->Yield();" : ";";
 	Emit("auto t = " + op1 + "->GetType()" + type_suffix);


### PR DESCRIPTION
This PR fixes a bug when a relational operator has a constant as its first argument. Normally this doesn't matter, but it does for the particular case of /pattern/ == string constructs. Once this is merged, I'll put in a Zeek update that catches future problems (no change to Zeek, just altering a test case so that for ZAM it tests whether this is working properly).