### PR TITLE
More robust dispatch that allows for eval/eval-mixed overlap

### DIFF
--- a/src/Gen-ZAM.h
+++ b/src/Gen-ZAM.h
@@ -851,6 +851,8 @@ protected:
 
 	void BuildInstruction(const OCVec& oc, const string& params,
 	                      const string& suffix, ZAM_InstClass zc) override;
+
+	void GenerateSecondTypeVars(const OCVec& oc, ZAM_InstClass zc);
 	};
 
 // A version of ZAM_BinaryExprOpTemplate for relationals.


### PR DESCRIPTION
Previously, `gen-zam` produced code for deciding which flavor of an expression to generate based on just the type of the first operand, with an exception for mixed-typed operands ... as long as one of the types in those differed from any of the other flavors. That doesn't work however for the new `pattern` equality operators because there's now both a direct version (two `pattern` operands) and a mixed version (a `pattern` and a `string`). This PR changes such dispatch to always examine the types of both operands. The change isn't fully backward compatible due to some AST type-checking/lack-of-coercion issues that were previously masked but now manifest. Those are fixed in a parallel Zeek PR that I'll be putting in shortly, so this needs to wait on that.