### PR TITLE
Require C++20 for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(Gen-ZAM C CXX)
 
 include(cmake/CommonCMakeConfig.cmake)
 
-include(RequireCXX17)
+include(RequireCXXStd)
 
 set(GEN_ZAM_SRCS src/Gen-ZAM.cc)
 set(GEN_ZAM_HEADERS src/Gen-ZAM.h)


### PR DESCRIPTION
This bumps the cmake submodule to a version that requires C++20 and makes a few other minor changes to use that.