### PR TITLE
Fix a pile of Coverity findings

### DIFF
--- a/src/Gen-ZAM.h
+++ b/src/Gen-ZAM.h
@@ -370,8 +370,8 @@ protected:
     // operation that explictly omits any assignment.
     bool HasAssignmentLess() const { return ! assignment_less_op.empty(); }
     void SetAssignmentLess(string op, string op_class) {
-        assignment_less_op = op;
-        assignment_less_op_class = op_class;
+        assignment_less_op = std::move(op);
+        assignment_less_op_class = std::move(op_class);
     }
     const string& AssignmentLessOp() const { return assignment_less_op; }
     const string& AssignmentLessOpClass() const { return assignment_less_op_class; }


### PR DESCRIPTION
This is just a bunch of minor fixes to get them out of the list. They generally fall into these buckets:

- Use `const auto&` references to avoid copies for variables that aren't ever written to.
- `std::move`
- Use `[[fallthrough]]` annotations for switch/case statements without `break`s.